### PR TITLE
Fix translation of basso

### DIFF
--- a/DailyWord/Languages/Italian.swift
+++ b/DailyWord/Languages/Italian.swift
@@ -612,7 +612,7 @@ class Italian : LanguageBase {
         Word(native: "useless", foreign: "inutile"),
         Word(native: "national", foreign: "nazionale"),
         Word(native: "modern", foreign: "moderno"),
-        Word(native: "bass", foreign: "basso"),
+        Word(native: "short", foreign: "basso"),
         Word(native: "numerous", foreign: "numeroso"),
         Word(native: "simple", foreign: "semplice"),
         Word(native: "similar", foreign: "simile"),


### PR DESCRIPTION
Fixes translation of the Italian word basso, which means short. See WordReference for more details: https://www.wordreference.com/iten/basso